### PR TITLE
Allow specifying custom options for multi-tenancy on a schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,30 @@ client.live?
 client.ready?
 ```
 
+### Tenants
+
+Any schema can be multi-tenant
+
+```ruby
+client.schema.create(
+    # Other keys...
+    mutli_tenant: true, # passes { enabled: true } to weaviate
+)
+```
+
+You can also manually specify your multi tenancy configuration with a hash
+
+```ruby
+client.schema.create(
+    # Other keys...
+    mutli_tenant: { enabled: true, autoTenantCreation: true, autoTenantActivation: true },
+)
+```
+
+See [Weaviate Multi-tenancy operations](https://weaviate.io/developers/weaviate/manage-data/multi-tenancy). Note that the mix of snake case(used by Ruby) and lower camel case(used by Weaviate) is intentional as that hash is passed directly to Weaviate.
+
+All data methods in this library support an optional `tenant` argument which must be passed if multi-tenancy is enabled on the related collection
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/weaviate/schema.rb
+++ b/lib/weaviate/schema.rb
@@ -43,7 +43,11 @@ module Weaviate
         req.body["vectorizer"] = vectorizer unless vectorizer.nil?
         req.body["moduleConfig"] = module_config unless module_config.nil?
         req.body["properties"] = properties unless properties.nil?
-        req.body["multiTenancyConfig"] = {enabled: true} unless multi_tenant.nil?
+        if multi_tenant.is_a?(Hash)
+          req.body["multiTenancyConfig"] = multi_tenant
+        elsif multi_tenant.present?
+          req.body["multiTenancyConfig"] = {enabled: true}
+        end
         req.body["invertedIndexConfig"] = inverted_index_config unless inverted_index_config.nil?
         req.body["replicationConfig"] = replication_config unless replication_config.nil?
       end


### PR DESCRIPTION
Issue: 

Currently this library can only enable multi-tenancy but no further options

Solution: 

Allow the user to specify any options they want for multi-tenancy when creating a schema using their own hash
Update readme for multi-tenancy