### PR TITLE
Add object.replace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+## [0.9.0] - 2024-07-08
+
+- Add object.replace method which uses PUT which performs a complete object replacement
+
+### Breaking
+- Change the object.update method to use PATCH which only performs a partial update(previously performed a replacement)
+
+## [0.8.11] - 2024-07-02
+- Allow the user to specify any options they want for multi-tenancy when creating a schema using their own hash
+- Allow Ollama vectorizer
+
 ## [0.8.5] - 2023-07-19
 - Add multi-tenancy support
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    weaviate-ruby (0.8.10)
+    weaviate-ruby (0.9.0)
       faraday (>= 2.0.1, < 3.0)
       graphlient (~> 0.7.0)
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ client.objects.exists?(
     id: "uuid"
 )
 
-# Delete a single data object from Weaviate.
-client.objects.delete(
+# Perform a partial update on an object based on its uuid.
+client.objects.update(
     class_name: "Question",
-    id: "uuid"
+    id: "uuid",
+    properties: {
+        category: "simple-math"
+    }
 )
 
-# Update a single data object based on its uuid.
-client.objects.update(
+# Replace an object based on its uuid.
+client.objects.replace(
     class_name: "Question",
     id: "uuid",
     properties: {
@@ -138,6 +141,12 @@ client.objects.update(
         category: "math",
         answer: "42"
     }
+)
+
+# Delete a single data object from Weaviate.
+client.objects.delete(
+    class_name: "Question",
+    id: "uuid"
 )
 
 # Batch create objects

--- a/lib/weaviate/objects.rb
+++ b/lib/weaviate/objects.rb
@@ -122,7 +122,7 @@ module Weaviate
     )
       validate_consistency_level!(consistency_level) unless consistency_level.nil?
 
-       response = client.connection.patch("#{PATH}/#{class_name}/#{id}") do |req|
+      response = client.connection.patch("#{PATH}/#{class_name}/#{id}") do |req|
         req.params["consistency_level"] = consistency_level.to_s.upcase unless consistency_level.nil?
 
         req.body = {}

--- a/lib/weaviate/objects.rb
+++ b/lib/weaviate/objects.rb
@@ -122,6 +122,31 @@ module Weaviate
     )
       validate_consistency_level!(consistency_level) unless consistency_level.nil?
 
+       response = client.connection.patch("#{PATH}/#{class_name}/#{id}") do |req|
+        req.params["consistency_level"] = consistency_level.to_s.upcase unless consistency_level.nil?
+
+        req.body = {}
+        req.body["id"] = id
+        req.body["class"] = class_name
+        req.body["properties"] = properties
+        req.body["vector"] = vector unless vector.nil?
+        req.body["tenant"] = tenant unless tenant.nil?
+      end
+
+      response.body
+    end
+
+    # Replace an individual data object based on its uuid.
+    def replace(
+      class_name:,
+      id:,
+      properties:,
+      vector: nil,
+      tenant: nil,
+      consistency_level: nil
+    )
+      validate_consistency_level!(consistency_level) unless consistency_level.nil?
+
       response = client.connection.put("#{PATH}/#{class_name}/#{id}") do |req|
         req.params["consistency_level"] = consistency_level.to_s.upcase unless consistency_level.nil?
 

--- a/lib/weaviate/version.rb
+++ b/lib/weaviate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Weaviate
-  VERSION = "0.8.10"
+  VERSION = "0.9.0"
 end

--- a/spec/weaviate/objects_spec.rb
+++ b/spec/weaviate/objects_spec.rb
@@ -132,13 +132,36 @@ RSpec.describe Weaviate::Objects do
     let(:response) { OpenStruct.new(success?: true, body: object_fixture) }
 
     before do
-      allow_any_instance_of(Faraday::Connection).to receive(:put)
+      allow_any_instance_of(Faraday::Connection).to receive(:patch)
         .with("objects/Question/123")
         .and_return(response)
     end
 
     it "returns the schema" do
       response = objects.update(
+        class_name: "Question",
+        id: "123",
+        properties: {
+          question: "What does 6 times 7 equal to?",
+          category: "math",
+          answer: "42"
+        }
+      )
+      expect(response.dig("class")).to eq("Question")
+    end
+  end
+
+  describe "#replace" do
+    let(:response) { OpenStruct.new(success?: true, body: object_fixture) }
+
+    before do
+      allow_any_instance_of(Faraday::Connection).to receive(:put)
+        .with("objects/Question/123")
+        .and_return(response)
+    end
+
+    it "returns the schema" do
+      response = objects.replace(
         class_name: "Question",
         id: "123",
         properties: {


### PR DESCRIPTION
Update the object.update method to use PATCH which only performs a partial update
Add object.replace method which uses PUT which performs a complete object replacement

The issue is this is considered a breaking change since object.update previously did a replace but now just does an update. I'm unsure how the maintainer would like to handle this.