### PR TITLE
Drop old ruby support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@master
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler: default
           bundler-cache: true
       - name: Build docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.10.0] - 2024-07-08
+- Drop support for end-of-life Ruby versions. Ruby >= 3.1 required
+
 ## [0.9.0] - 2024-07-08
 
 - Add object.replace method which uses PUT which performs a complete object replacement

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ client.schema.create(
 ### Using the Objects endpoint
 ```ruby
 # Create a new data object. 
-client.objects.create(
+output = client.objects.create(
     class_name: 'Question',
     properties: {
         answer: '42',
@@ -152,6 +152,7 @@ client.objects.create(
         category: 'philosophy'
     }
 )
+uuid = output["id"]
 
 # Lists all data objects in reverse order of creation.
 client.objects.list()
@@ -159,19 +160,19 @@ client.objects.list()
 # Get a single data object.
 client.objects.get(
     class_name: "Question",
-    id: "uuid"
+    id: uuid
 )
 
 # Check if a data object exists.
 client.objects.exists?(
     class_name: "Question",
-    id: "uuid"
+    id: uuid
 )
 
 # Perform a partial update on an object based on its uuid.
 client.objects.update(
     class_name: "Question",
-    id: "uuid",
+    id: uuid,
     properties: {
         category: "simple-math"
     }
@@ -180,7 +181,7 @@ client.objects.update(
 # Replace an object based on its uuid.
 client.objects.replace(
     class_name: "Question",
-    id: "uuid",
+    id: uuid,
     properties: {
         question: "What does 6 times 7 equal to?",
         category: "math",
@@ -191,34 +192,35 @@ client.objects.replace(
 # Delete a single data object from Weaviate.
 client.objects.delete(
     class_name: "Question",
-    id: "uuid"
+    id: uuid
 )
 
 # Batch create objects
-client.objects.batch_create(objects: [
+output = client.objects.batch_create(objects: [
     {
         class: "Question",
         properties: {
-        answer: "42",
-        question: "What is the meaning of life?",
-        category: "philosophy"
+            answer: "42",
+            question: "What is the meaning of life?",
+            category: "philosophy"
         }
     }, {
         class: "Question",
         properties: {
-        answer: "42",
-        question: "What does 6 times 7 equal to?",
-        category: "math"
+            answer: "42",
+            question: "What does 6 times 7 equal to?",
+            category: "math"
         }
     }
 ])
+uuids = output.pluck("id")
 
 # Batch delete objects
 client.objects.batch_delete(
     class_name: "Question",
     where: {
-        valueString: "uuid",
-        operator: "Equal",
+        valueStringArray: uuids,
+        operator: "ContainsAny",
         path: ["id"]
     }
 )

--- a/weaviate.gemspec
+++ b/weaviate.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Ruby wrapper for the Weaviate.io API"
   spec.homepage = "https://github.com/andreibondarev/weaviate-ruby"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/andreibondarev/weaviate-ruby"


### PR DESCRIPTION
Drop support for old end-of-life Ruby versions. 3.1 or newer required