### PR TITLE
change from `present?` (Rails) to native Ruby check

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Any schema can be multi-tenant
 ```ruby
 client.schema.create(
     # Other keys...
-    mutli_tenant: true, # passes { enabled: true } to weaviate
+    multi_tenant: true, # passes { enabled: true } to weaviate
 )
 ```
 
@@ -368,7 +368,18 @@ You can also manually specify your multi tenancy configuration with a hash
 ```ruby
 client.schema.create(
     # Other keys...
-    mutli_tenant: { enabled: true, autoTenantCreation: true, autoTenantActivation: true },
+    multi_tenant: { enabled: true, autoTenantCreation: true, autoTenantActivation: true },
+)
+```
+
+Added shortcuts for `multiTenancyConfig`:
+
+```ruby
+client.schema.create(
+    # Other keys...
+    multi_tenant: true,
+    auto_tenant_creation: true,
+    auto_tenant_activation: true
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -354,25 +354,7 @@ client.ready?
 
 ### Tenants
 
-Any schema can be multi-tenant
-
-```ruby
-client.schema.create(
-    # Other keys...
-    multi_tenant: true, # passes { enabled: true } to weaviate
-)
-```
-
-You can also manually specify your multi tenancy configuration with a hash
-
-```ruby
-client.schema.create(
-    # Other keys...
-    multi_tenant: { enabled: true, autoTenantCreation: true, autoTenantActivation: true },
-)
-```
-
-Added shortcuts for `multiTenancyConfig`:
+Any schema can be multi-tenant by passing in these options for to `schema.create()`.
 
 ```ruby
 client.schema.create(

--- a/lib/weaviate/objects.rb
+++ b/lib/weaviate/objects.rb
@@ -50,7 +50,7 @@ module Weaviate
         req.body = {}
         req.body["class"] = class_name
         req.body["properties"] = properties
-        req.body["tenant"] = tenant unless tenant.blank?
+        req.body["tenant"] = tenant unless tenant.nil?
         req.body["id"] = id unless id.nil?
         req.body["vector"] = vector unless vector.nil?
       end

--- a/lib/weaviate/schema.rb
+++ b/lib/weaviate/schema.rb
@@ -45,7 +45,7 @@ module Weaviate
         req.body["properties"] = properties unless properties.nil?
         if multi_tenant.is_a?(Hash)
           req.body["multiTenancyConfig"] = multi_tenant
-        elsif multi_tenant.present?
+        elsif multi_tenant && !(multi_tenant.respond_to?(:empty?) && multi_tenant.empty?)
           req.body["multiTenancyConfig"] = {enabled: true}
         end
         req.body["invertedIndexConfig"] = inverted_index_config unless inverted_index_config.nil?

--- a/lib/weaviate/schema.rb
+++ b/lib/weaviate/schema.rb
@@ -27,6 +27,7 @@ module Weaviate
       description: nil,
       properties: nil,
       multi_tenant: nil,
+      auto_tenant_creation: nil,
       vector_index_type: nil,
       vector_index_config: nil,
       vectorizer: nil,
@@ -45,8 +46,9 @@ module Weaviate
         req.body["properties"] = properties unless properties.nil?
         if multi_tenant.is_a?(Hash)
           req.body["multiTenancyConfig"] = multi_tenant
-        elsif multi_tenant && !(multi_tenant.respond_to?(:empty?) && multi_tenant.empty?)
-          req.body["multiTenancyConfig"] = {enabled: true}
+        elsif !multi_tenant.nil?
+          req.body["multiTenancyConfig"] = { enabled: true }
+          req.body["multiTenancyConfig"].merge!(autoTenantCreation: true) unless auto_tenant_creation.nil?
         end
         req.body["invertedIndexConfig"] = inverted_index_config unless inverted_index_config.nil?
         req.body["replicationConfig"] = replication_config unless replication_config.nil?

--- a/lib/weaviate/schema.rb
+++ b/lib/weaviate/schema.rb
@@ -26,9 +26,9 @@ module Weaviate
       class_name:,
       description: nil,
       properties: nil,
-      multi_tenant: nil,
-      auto_tenant_creation: nil,
-      auto_tenant_activation: nil,
+      multi_tenant: false,
+      auto_tenant_creation: false,
+      auto_tenant_activation: false,
       vector_index_type: nil,
       vector_index_config: nil,
       vectorizer: nil,
@@ -45,13 +45,15 @@ module Weaviate
         req.body["vectorizer"] = vectorizer unless vectorizer.nil?
         req.body["moduleConfig"] = module_config unless module_config.nil?
         req.body["properties"] = properties unless properties.nil?
-        if multi_tenant.is_a?(Hash)
-          req.body["multiTenancyConfig"] = multi_tenant
-        elsif !multi_tenant.nil?
-          req.body["multiTenancyConfig"] = { enabled: true }
-          req.body["multiTenancyConfig"].merge!(autoTenantCreation: true) unless auto_tenant_creation.nil?
-          req.body["multiTenancyConfig"].merge!(autoTenantActivation: true) unless auto_tenant_activation.nil?
+
+        if multi_tenant
+          req.body["multiTenancyConfig"] = {
+            enabled: multi_tenant,
+            autoTenantCreation: auto_tenant_creation,
+            autoTenantActivation: auto_tenant_activation
+          }
         end
+
         req.body["invertedIndexConfig"] = inverted_index_config unless inverted_index_config.nil?
         req.body["replicationConfig"] = replication_config unless replication_config.nil?
       end

--- a/lib/weaviate/schema.rb
+++ b/lib/weaviate/schema.rb
@@ -28,6 +28,7 @@ module Weaviate
       properties: nil,
       multi_tenant: nil,
       auto_tenant_creation: nil,
+      auto_tenant_activation: nil,
       vector_index_type: nil,
       vector_index_config: nil,
       vectorizer: nil,
@@ -49,6 +50,7 @@ module Weaviate
         elsif !multi_tenant.nil?
           req.body["multiTenancyConfig"] = { enabled: true }
           req.body["multiTenancyConfig"].merge!(autoTenantCreation: true) unless auto_tenant_creation.nil?
+          req.body["multiTenancyConfig"].merge!(autoTenantActivation: true) unless auto_tenant_activation.nil?
         end
         req.body["invertedIndexConfig"] = inverted_index_config unless inverted_index_config.nil?
         req.body["replicationConfig"] = replication_config unless replication_config.nil?

--- a/spec/weaviate/schema_spec.rb
+++ b/spec/weaviate/schema_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Weaviate::Schema do
           auto_tenant_activation: true
         )
 
-        expect(@captured_request.body["multiTenancyConfig"]).to eq({ enabled: true, autoTenantCreation: true, autoTenantActivation: true })
+        expect(@captured_request.body["multiTenancyConfig"]).to eq({enabled: true, autoTenantCreation: true, autoTenantActivation: true})
       end
     end
   end

--- a/spec/weaviate/schema_spec.rb
+++ b/spec/weaviate/schema_spec.rb
@@ -89,15 +89,16 @@ RSpec.describe Weaviate::Schema do
         end
       end
 
-      it "sets up multiTenancyConfig with autoTenantCreation enabled" do
+      it "sets up multiTenancyConfig with autoTenantCreation and autoTenantActivation enabled" do
         schema.create(
           class_name: "Question",
           description: "Information from a Jeopardy! question",
           multi_tenant: true,
-          auto_tenant_creation: true
+          auto_tenant_creation: true,
+          auto_tenant_activation: true
         )
 
-        expect(@captured_request.body["multiTenancyConfig"]).to eq({ enabled: true, autoTenantCreation: true })
+        expect(@captured_request.body["multiTenancyConfig"]).to eq({ enabled: true, autoTenantCreation: true, autoTenantActivation: true })
       end
     end
   end

--- a/spec/weaviate/schema_spec.rb
+++ b/spec/weaviate/schema_spec.rb
@@ -76,6 +76,30 @@ RSpec.describe Weaviate::Schema do
       )
       expect(response.dig("class")).to eq("Question")
     end
+
+    context "when auto_tenant_creation passed" do
+      before do
+        @captured_request = nil
+        allow_any_instance_of(Faraday::Connection).to receive(:post) do |_, path, &block|
+          expect(path).to eq("schema")
+          req = OpenStruct.new(body: {})
+          block.call(req)
+          @captured_request = req
+          response
+        end
+      end
+
+      it "sets up multiTenancyConfig with autoTenantCreation enabled" do
+        schema.create(
+          class_name: "Question",
+          description: "Information from a Jeopardy! question",
+          multi_tenant: true,
+          auto_tenant_creation: true
+        )
+
+        expect(@captured_request.body["multiTenancyConfig"]).to eq({ enabled: true, autoTenantCreation: true })
+      end
+    end
   end
 
   describe "#delete" do


### PR DESCRIPTION
I'm not sure where `present?` (a method defined in Rails) is being pulled in from, but for me, it's not:

```sh
NoMethodError: undefined method `present?' for nil (NoMethodError)

        elsif multi_tenant.present?
                          ^^^^^^^^^
```

I wonder if a truthiness check is good enough: `elsif multi_tenant` 

or do we need to explicitly check that it's not empty, similar to `present?`